### PR TITLE
ログイン・新規登録エンドポイントの仕様変更

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,8 +6,7 @@ class SessionsController < ApplicationController
       if error
         render json: { message: error }, status: :unauthorized
       else
-        response.headers["X-Api-Token"] = user.api_token
-        render json: user
+        render json: { api_token: user.api_token }
       end
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,11 +1,5 @@
 class UsersController < ApplicationController
   skip_before_action :authenticate, only: :create
-
-  def show
-    user = User.find(params[:id])
-    render json: user
-  end
-
   def create
     user = User.new(user_params)
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,8 +10,7 @@ class UsersController < ApplicationController
     user = User.new(user_params)
 
     if user.save
-      response.headers["X-Api-Token"] = user.api_token
-      render json: user
+      render json: { api_token: user.api_token }
     else
       render json: { message: user.errors.full_messages.join("\n") }, status: :unprocessable_entity
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,6 @@ Rails.application.routes.draw do
     delete 'favorites' => 'favorites#destroy'
   end
 
-  resources :users, only: [:show, :create]
   post 'login' => 'sessions#create'
+  post 'signup' => 'users#create'
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe UsersController, type: :controller do
-
-end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,17 +1,8 @@
 RSpec.describe "Users", type: :request do
-  describe "GET /users/:id" do
-    let(:user) { FactoryBot.create :user }
-    subject { get user_path(user), headers: { Authorization: "Token #{user.api_token}" } }
-    it 'success' do
-      subject
-      expect(response).to be_success
-    end
-  end
-
-  describe "POST /users" do
+  describe "POST /signup" do
     context '適切なパラメータを与えた場合' do
       subject {
-        post users_path, params: {
+        post signup_path, params: {
           email: 'sample@sample.com',
           password: 'a' * 8,
         }
@@ -20,11 +11,6 @@ RSpec.describe "Users", type: :request do
       it 'success' do
         subject
         expect(response).to be_success
-      end
-
-      it 'Api-Tokenが設定される' do
-        subject
-        expect(response.headers['X-Api-Token']).to be_present
       end
 
       it 'ユーザー数が増える' do
@@ -36,7 +22,7 @@ RSpec.describe "Users", type: :request do
 
     context 'パラメータが不適切な場合' do
       subject {
-        post users_path, params: {
+        post signup_path, params: {
           email: 'not_include_domain',
           password: 'short'
         }


### PR DESCRIPTION
* Apiキーはheaderではなくbodyで返す
* 新規ユーザー登録のurlをsignupに変更
* 不要エンドポイント(/users/:id)の削除